### PR TITLE
requester_pays feature

### DIFF
--- a/R/gsutil.R
+++ b/R/gsutil.R
@@ -111,7 +111,11 @@ NULL
     args <- c('config', 'list', 'project')
     res <- system2(gcloud, args, stdout = TRUE, stderr=TRUE)[2]
     ## Get project
-    gsub("project = ", "", res)
+    project <- gsub("project = ", "", res)
+    ## stop if project is not available
+    if (!nzchar(project))
+        stop("billing project missing, check 'gcloud config list'.")
+    project
 }
 
 ## evaluate the gsutil command and arguments in `args`

--- a/man/gsutil.Rd
+++ b/man/gsutil.Rd
@@ -11,19 +11,21 @@
 \alias{gsutil_help}
 \title{Interact with the gsutil command line utility}
 \usage{
-gsutil_ls(source = character(), ..., recursive = FALSE)
+gsutil_ls(source = character(), ..., recursive = FALSE,
+  requester_pays = FALSE)
 
-gsutil_exists(source)
+gsutil_exists(source, requester_pays = FALSE)
 
-gsutil_stat(source)
+gsutil_stat(source, requester_pays = FALSE)
 
-gsutil_cp(source, destination, ..., recursive = FALSE, parallel = TRUE)
+gsutil_cp(source, destination, ..., recursive = FALSE, parallel = TRUE,
+  requester_pays = FALSE)
 
 gsutil_rm(source, ..., force = FALSE, recursive = FALSE,
   parallel = TRUE)
 
 gsutil_rsync(source, destination, ..., dry = TRUE, delete = FALSE,
-  recursive = FALSE, parallel = TRUE)
+  recursive = FALSE, parallel = TRUE, requester_pays = FALSE)
 
 gsutil_help(cmd = character(0))
 }
@@ -36,6 +38,9 @@ with wild-cards for file-level pattern matching.}
 
 \item{recursive}{`logical(1)`; perform operation recursively from
 `source`?. Default: `FALSE`.}
+
+\item{requester_pays}{`logical(1)`; requester pays for operation
+from `source`. Default: `FALSE`.}
 
 \item{destination}{`character(1)`, google cloud bucket or local
 file system destination path.}

--- a/man/localize.Rd
+++ b/man/localize.Rd
@@ -7,13 +7,15 @@
 \alias{install}
 \title{Copy packages, folders, or files to or from google buckets.}
 \usage{
-localize(source, destination, dry = TRUE)
+localize(source, destination, dry = TRUE, requester_pays = FALSE)
 
-delocalize(source, destination, unlink = FALSE, dry = TRUE)
+delocalize(source, destination, unlink = FALSE, dry = TRUE,
+  requester_pays = FALSE)
 
 add_libpaths(paths)
 
-install(pkgs, lib = .libPaths()[1], lib.loc = NULL)
+install(pkgs, lib = .libPaths()[1], lib.loc = NULL,
+  requester_pays = FALSE)
 }
 \arguments{
 \item{source}{`character(1)`, a google storage bucket or local file
@@ -25,6 +27,9 @@ file system directory location.}
 \item{dry}{`logical(1)`, when `TRUE` (default), return the
 consequences of the operation without actually performing the
 operation.}
+
+\item{requester_pays}{`logical(1)`; requester pays for operation
+from `source`. Default: `FALSE`.}
 
 \item{unlink}{`logical(1)` remove (unlink) the file or directory
 in `source`. Default: `FALSE`.}
@@ -89,6 +94,9 @@ currently installed packages. Default is all paths in
 \dontrun{
 add_libpaths("/tmp/host-site-library")
 install(packages = c('BiocParallel', 'BiocGenerics'))
+
+## Pay to use google buckets
+install(packages = c('Biocstrings', 'GenomicRanges'), requester_pays=TRUE)
 }
 
 }


### PR DESCRIPTION
Example: 

Considering you have ` gcloud config list project` set to a valid billing project, then,

```
gsutil_ls("gs://bioconductor-full-devel", requester_pays = TRUE)

install(c("BiocParallel", "GenomicRanges"), requester_pays=TRUE)
```

The user gets billed instead of the host that is storing the data.

If you do not have a billing project set,

```
gcloud config set project <project_id>
```
