### PR TITLE
Fix for gsutil_requesterpays()

### DIFF
--- a/R/gsutil.R
+++ b/R/gsutil.R
@@ -55,7 +55,7 @@ gsutil_requesterpays <-
     function(source)
 {
     stopifnot(all(.gsutil_is_uri(source)))
-    project <- gcloud_project()
+    project <- gcloud_project()[2]
     buckets <- regmatches(source, regexpr("^gs://[^/]+", source))
     args <- c("-u", project, "requesterpays", "get", buckets)
     result <- .gsutil_do(args)


### PR DESCRIPTION
issue with `gsutil_cp()` or anything that uses requesterpays ->

```
Warning message:
'gsutil_requesterpays()' returned an error:
  'gsutil -u (unset) requesterpays get gs://firecloud-tcga-open-access gs://firecloud-tcga-open-access' failed:

  exit status: 2
```

Cause: `gcloud_project()` returns

```
 Browse[2]> project
 [1] "Your active configuration is: [nturaga]"
 [2] "mybillingaccount"
```
we need to only choose the [2] value in the vector returned by gcloud_project()