### PR TITLE
check for pre-existing column name after avtable_import_set operation

### DIFF
--- a/R/av.R
+++ b/R/av.R
@@ -381,8 +381,14 @@ avtable_import_set <-
     tbl <-
         .data %>%
         select(set, member)
-    names(tbl)[[1]] <- paste0("membership:", origin, "_set_id")
+    tname <- paste0(origin, "_set")
+    cname <- paste0(tname, "_id")
+    mname <- paste0("membership:", cname)
+    names(tbl)[[1]] <- mname
     names(tbl)[[2]] <- origin
+
+    if (all(unique(tbl[[mname]]) %in% avtable(tname)[[cname]]))
+        stop("Duplicate operation, delete rows or '", tname, "' from 'Data'")
 
     destination <- tempfile()
     write.table(tbl, destination, quote = FALSE, sep="\t", row.names=FALSE)


### PR DESCRIPTION
This closes #61 where a duplicate operation is performed. The code will check the unique values in the created column and produce an error if already run. 
