### PR TITLE
remove trimws for workspace names with leading space, closes #86

### DIFF
--- a/R/avworkspace.R
+++ b/R/avworkspace.R
@@ -53,7 +53,7 @@ avworkspaces <-
             accessLevel = .data$accessLevel
         ) %>%
         mutate(
-            name = trimws(.data$name),
+            name = .data$name,
             lastModified = as.Date(.data$lastModified)
         ) %>%
         arrange(

--- a/R/avworkspace.R
+++ b/R/avworkspace.R
@@ -27,6 +27,24 @@ NULL
     }
 })
 
+.avworkspaces_clean <- function(.data) {
+    .data |>
+        select(
+            name = .data$workspace.name,
+            lastModified = .data$workspace.lastModified,
+            createdBy = .data$workspace.createdBy,
+            namespace = .data$workspace.namespace,
+            accessLevel = .data$accessLevel
+        ) |>
+        mutate(
+            lastModified = as.Date(.data$lastModified)
+        ) |>
+        arrange(
+            .data$name,
+            desc(.data$lastModified)
+        )
+}
+
 #' @rdname avworkspace
 #'
 #' @description `avworkspaces()` returns a tibble with available
@@ -45,21 +63,7 @@ avworkspaces <-
     .avstop_for_status(response, "avworkspaces")
 
     flatten(response) %>%
-        select(
-            name = .data$workspace.name,
-            lastModified = .data$workspace.lastModified,
-            createdBy = .data$workspace.createdBy,
-            namespace = .data$workspace.namespace,
-            accessLevel = .data$accessLevel
-        ) %>%
-        mutate(
-            name = .data$name,
-            lastModified = as.Date(.data$lastModified)
-        ) %>%
-        arrange(
-            .data$name,
-            desc(.data$lastModified)
-        )
+        .avworkspaces_clean()
 }
 
 #' @rdname avworkspace

--- a/tests/testthat/test_av.R
+++ b/tests/testthat/test_av.R
@@ -116,3 +116,28 @@ test_that(".avbucket_path() trims arguments correctly", {
         .avbucket_path("gs://foo", "bar", c("baz", "bing"))
     )
 })
+
+test_that(".av_workspaces_clean() preserves leading and trailing spaces", {
+    ## add intentional spaces in workspace.name
+    testws <- tibble::tibble(
+        workspace.name = " a test workspace ",
+        workspace.lastModified = "2023-06-26T21:17:26.343Z",
+        workspace.createdBy = "test.bioc@gmail.com",
+        workspace.namespace = "bioconductor-rpci-anvil",
+        accessLevel = "READER",
+        extraCol = TRUE
+    )
+    restbl <- testws
+    ## for testing names
+    coi <- c("name", "lastModified", "createdBy", "namespace", "accessLevel")
+    names(restbl) <- coi
+    ## for testing select operation
+    restbl <- restbl[, coi]
+    ## for testing Date coercion
+    restbl[["lastModified"]] <- as.Date(restbl[["lastModified"]])
+
+    expect_identical(
+        .avworkspaces_clean(testws),
+        restbl
+    )
+})


### PR DESCRIPTION
- no effect for trailing spaces