### PR TITLE
catch return status as error in response

### DIFF
--- a/R/av.R
+++ b/R/av.R
@@ -643,12 +643,20 @@ avtable_import_status <-
             } else {
                 updated_message[[job_index]] <- NA_character_
             }
+            if (identical(tolower(content$status),  "error"))
+                stop(
+                    "job failed with error status: ",
+                    updated_message[[job_index]], call. = FALSE
+                )
         }, error = function(err) {
+            err_msg <- conditionMessage(err)
+            is_err_status <- grepl("job failed with error status", err_msg)
+            status_msg <- if (is_err_status) "error" else "failed to get"
             msg <- paste(strwrap(paste0(
-                "failed to get status of job_id '", job_id, "'; ",
+                status_msg, " status of job_id '", job_id, "'; ",
                 "continuing to next job"
             )), collapse = "\n")
-            warning(msg, "\n", conditionMessage(err), immediate. = TRUE)
+            warning(msg, "\n", err_msg, immediate. = TRUE)
         })
         if (!is.null(progress_bar))
             setTxtProgressBar(progress_bar, job_index)


### PR DESCRIPTION
Hi Martin, @mtmorgan 
In doing some testing, I found a bug where the API response job status is an error but `.avstop_for_status` did not catch it. 
I suppose it could but the prefixed warning message (`msg` modified in this PR) would not make sense. This type of `content$status == "Error"` may also only be specific to job status requests. 